### PR TITLE
update instructions; use http-server instead of recommending python's server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## aframe extrude and lathe components
 
-Components for [A-Frame](https://aframe.io).  
+Components for [A-Frame](https://aframe.io).
 Based on [aframe-component-boilerplate](https://github.com/ngokevin/aframe-component-boilerplate).
 
 This module offers lathe and extrude components.
@@ -22,11 +22,12 @@ This module offers lathe and extrude components.
 ### Development
 
     npm install
-    python -m SimpleHTTPServer 5566 &
+    npm start
     cd examples
+    npm install
     npm run build
 
-visit <http://127.0.0.1:5566/examples/basic/index.html>
+Visit [http://127.0.0.1:5566/examples/basic/index.html](http://127.0.0.1:5566/examples/basic/index.html)
 
 
 

--- a/examples/package.json
+++ b/examples/package.json
@@ -5,7 +5,7 @@
     "watchify": "^3.6.1"
   },
   "scripts": {
-    "build": "browserify main.js -o build.js ",
+    "build": "browserify main.js -o build.js",
     "dev": "watchify main.js -o build.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,11 +4,12 @@
   "description": "extrude and lathe components for aframevr",
   "main": "index.js",
   "scripts": {
+    "start": "http-server -c-1 -p 5566",
     "test": "karma start ./tests/karma.conf.js"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ngokevin/aframe-example-component.git"
+    "url": "git+https://github.com/JosePedroDias/aframe-example-component.git"
   },
   "keywords": [
     "aframe",


### PR DESCRIPTION
since npm is already a dependency. and Python's `SimpleHTTPServer` does that silly thing where it appends `/` slashes - and Python doesn't ship by default with Windows, for example. so that'd make Node and Python two dependencies.

let me know what you thought.
